### PR TITLE
Remove csv from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 python-dotenv
 fuzzywuzzy
-csv
 google-api-python-client
 yt-dlp
 json


### PR DESCRIPTION
From what it looks like, csv is a built-in Python library and does not need to be in requirements.txt