### PR TITLE
Remove csv and json from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 python-dotenv
 fuzzywuzzy
-csv
 google-api-python-client
 yt-dlp
 json

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ python-dotenv
 fuzzywuzzy
 google-api-python-client
 yt-dlp
-json


### PR DESCRIPTION
"csv" and "json" appear to be built-in modules for Python and therefore do not need to be in requirements.txt