### PR TITLE
Change 'seconds' to 'duration' in duration_check.py

### DIFF
--- a/modules/duration_check.py
+++ b/modules/duration_check.py
@@ -61,7 +61,7 @@ def check_duration(input):
                         (
                             title,
                             uploader,
-                            seconds,
+                            duration,
                             upload_date_str,
                         ) = data_pulling.check_with_yt_dlp(video_link=video_link)
                         seconds = int(duration)


### PR DESCRIPTION
Probably a typo. Creates an error unless duration is properly initialized. 