### PR TITLE
Updated how [DUPLICATE CREATOR] and [5 CHANNEL RULE] are appended to processed.csv

### DIFF
--- a/modules/duration_check.py
+++ b/modules/duration_check.py
@@ -38,7 +38,8 @@ def check_duration(input):
                             duration,
                             upload_date_str,
                         ) = data_pulling.yt_api(video_id)
-                        if seconds:
+
+                        if int(duration):
                             seconds = int(duration)
                         else:
                             print("[DURATION CHECK] ERROR NO VIDEO DATA PROCEEDING WITH '0'")

--- a/modules/uploader_diversity.py
+++ b/modules/uploader_diversity.py
@@ -1,5 +1,4 @@
 import csv
-from modules import uploader_occurence
 
 input_file_path = "outputs/temp_outputs/uploaders_output.csv"
 # input_file_path = "outputs/temp_outputs/test_input_delete.csv"
@@ -34,10 +33,21 @@ def check_uploader_diversity():
                 for cell_number in range(2, len(processed_rows[line_number])):
                     # For each corresponding cell in processed.csv
                     cell = processed_rows[line_number][cell_number]
-                    if cell != "" and not uploader_occurence.contains_note(cell):
+                    if cell != "" and not contains_note(cell):
                     # If cell is a video title
                         processed_rows[line_number][cell_number + 1] += "[5 CHANNEL RULE]"
                         # Append note to notes column
 
         output_file.seek(0)
         processed_writer.writerows(processed_rows)
+
+with open("modules/csv/possible_notes.csv", "r") as csvfile:
+    notes = []
+    reader = csv.reader(csvfile)
+    for row in reader:
+        notes.extend(row)
+    # Initialize list of notes for contains_note() check.
+
+def contains_note(cell): 
+# Returns true if cell contains at least one note, e.g. [DUPLICATE CREATOR]
+    return any(domain in cell for domain in notes)

--- a/modules/uploader_diversity.py
+++ b/modules/uploader_diversity.py
@@ -1,4 +1,5 @@
 import csv
+from modules import uploader_occurence
 
 input_file_path = "outputs/temp_outputs/uploaders_output.csv"
 # input_file_path = "outputs/temp_outputs/test_input_delete.csv"
@@ -32,10 +33,11 @@ def check_uploader_diversity():
                 # If this submission has < 5 unique uploaders
                 for cell_number in range(2, len(processed_rows[line_number])):
                     # For each corresponding cell in processed.csv
-                    if processed_rows[line_number][cell_number] != "":
-                        # If current cell is not empty
-                        processed_rows[line_number][cell_number] += "[5 CHANNEL RULE]"
-                        # Append note to cell
+                    cell = processed_rows[line_number][cell_number]
+                    if cell != "" and not uploader_occurence.contains_note(cell):
+                    # If cell is a video title
+                        processed_rows[line_number][cell_number + 1] += "[5 CHANNEL RULE]"
+                        # Append note to notes column
 
         output_file.seek(0)
         processed_writer.writerows(processed_rows)

--- a/modules/uploader_occurence.py
+++ b/modules/uploader_occurence.py
@@ -4,10 +4,10 @@ input_file = "outputs/temp_outputs/uploaders_output.csv"
 main_file = "outputs/processed.csv"
 
 def check_uploader_occurence():
-# Checks the names of all uploaders within every submission.
+# Checks the names of all uploaders for every submission.
 # If a particular uploader shows up 3 times or more in a submission,
-# each cell of the submission in processed.csv is flagged with the
-# "[DUPLICATE CREATOR]" tag to signify that the entire submission is invalidated.
+# the note "[DUPLICATE CREATOR]" is appended to the notes column
+# of every video uploaded by the duplicate creator in processed.csv
 
     with open(input_file, "r", encoding="utf-8") as csvfile, open(
         main_file, "r", encoding="utf-8"
@@ -31,25 +31,13 @@ def check_uploader_occurence():
                 if count >= 3:
                 # If this uploader appears 3 times or more
                     for i in range(2, len(row)):
-                        # For each corresponding cell in processed.csv
-                        cell = main_rows[line_number - 1][i]
-                        if cell != "" and not contains_note(cell):
-                        # If cell is a video title
+                    # For each cell
+                        if (rows[line_number - 1][i] == uploader):
+                        # If this cell in uploaders_output.csv is the duplicate creator
                             main_rows[line_number - 1][i + 1] += "[DUPLICATE CREATOR]"
-                            # Append note to notes column
+                            # Append note to notes column for corresponding cell in processed.csv
 
     # Write to processed.csv
     with open(main_file, "w", newline="", encoding="utf-8") as processed_uploaders_csv:
         writer = csv.writer(processed_uploaders_csv)
         writer.writerows(main_rows)
-
-with open("modules/csv/possible_notes.csv", "r") as csvfile:
-    notes = []
-    reader = csv.reader(csvfile)
-    for row in reader:
-        notes.extend(row)
-    # Initialize list of notes for contains_note() check.
-
-def contains_note(cell): 
-# Returns true if cell contains at least one note, e.g. [DUPLICATE CREATOR]
-    return any(domain in cell for domain in notes)

--- a/modules/uploader_occurence.py
+++ b/modules/uploader_occurence.py
@@ -1,16 +1,13 @@
 import csv
 
 input_file = "outputs/temp_outputs/uploaders_output.csv"
-output_file = "outputs/processed_uploaders.csv"
 main_file = "outputs/processed.csv"
 
-
 def check_uploader_occurence():
-    # Checks the names of all uploaders within every submission.
-    # If a particular uploader shows up 3 times or more in a submission,
-    # each cell of the submission in processed.csv is flagged with the
-    # "[DUPLICATE CREATOR]" tag to signify that the entire submission is invalidated.
-    invalid_submissions = []
+# Checks the names of all uploaders within every submission.
+# If a particular uploader shows up 3 times or more in a submission,
+# each cell of the submission in processed.csv is flagged with the
+# "[DUPLICATE CREATOR]" tag to signify that the entire submission is invalidated.
 
     with open(input_file, "r", encoding="utf-8") as csvfile, open(
         main_file, "r", encoding="utf-8"
@@ -29,29 +26,22 @@ def check_uploader_occurence():
             for uploader in uploaders:
                 uploader_count[uploader] = uploader_count.get(uploader, 0) + 1
 
-            # Check if any uploader appears 3 or more times
             for uploader, count in uploader_count.items():
+            # For each uploader
                 if count >= 3:
-                    invalid_submissions.append(line_number)
-                    # Append the substring to each uploader in the row
+                # If this uploader appears 3 times or more
                     for i in range(2, len(row)):
                         # For each corresponding cell in processed.csv
-                        if main_rows[line_number - 1][i] != "":
-                            # If current cell is not empty
-                            main_rows[line_number - 1][i] += "[DUPLICATE CREATOR]"
+                        cell = main_rows[line_number - 1][i]
+                        if cell != "" and not contains_note(cell):
+                        # If cell is a video title
+                            main_rows[line_number - 1][i + 1] += "[DUPLICATE CREATOR]"
+                            # Append note to notes column
 
-    # Write the processed data to processed_uploaders.csv
+    # Write to processed.csv
     with open(main_file, "w", newline="", encoding="utf-8") as processed_uploaders_csv:
         writer = csv.writer(processed_uploaders_csv)
         writer.writerows(main_rows)
-
-    if invalid_submissions:
-        print(f"Processed data written to {output_file}")
-        print("Invalid submissions:")
-        for line_number in invalid_submissions:
-            print(
-                f"Line {line_number  - 1}: [DUPLICATE CREATOR] appended to uploader names"
-            )
 
 with open("modules/csv/possible_notes.csv", "r") as csvfile:
     notes = []
@@ -60,5 +50,6 @@ with open("modules/csv/possible_notes.csv", "r") as csvfile:
         notes.extend(row)
     # Initialize list of notes for contains_note() check.
 
-def contains_note(cell): # Returns true if cell contains at least one note, e.g. [DUPLICATE CREATOR]
+def contains_note(cell): 
+# Returns true if cell contains at least one note, e.g. [DUPLICATE CREATOR]
     return any(domain in cell for domain in notes)

--- a/modules/uploader_occurence.py
+++ b/modules/uploader_occurence.py
@@ -52,3 +52,13 @@ def check_uploader_occurence():
             print(
                 f"Line {line_number  - 1}: [DUPLICATE CREATOR] appended to uploader names"
             )
+
+with open("modules/csv/possible_notes.csv", "r") as csvfile:
+    notes = []
+    reader = csv.reader(csvfile)
+    for row in reader:
+        notes.extend(row)
+    # Initialize list of notes for contains_note() check.
+
+def contains_note(cell): # Returns true if cell contains at least one note, e.g. [DUPLICATE CREATOR]
+    return any(domain in cell for domain in notes)


### PR DESCRIPTION
- [DUPLICATE CREATOR] now only appends to the note columns corresponding to videos uploaded by the duplicate creator. Formerly, the note was appended to every cell, including the titles of the videos themselves.
- [5 CHANNEL RULE] now appends specifically to every notes column in a submission that contains the same uploader three times or more. 
- Removed some unused code in uploader_occurence.py