### PR TITLE
Update unavailable video handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,6 +68,8 @@ def run_checks():
         delete_if_present("outputs/temp_outputs/shifted_cells.csv")
         delete_if_present("outputs/temp_outputs/processed.csv")
 
+    tk.messagebox.showinfo("Processing Completed", "Processing Completed")
+
 
 def delete_if_present(filepath):
     """Delete the given file, if it exists on the filesystem."""

--- a/modules/fuzzy_check.py
+++ b/modules/fuzzy_check.py
@@ -42,10 +42,10 @@ def links_to_titles(input):  # Converts links to titles using Google API or yt_d
                             new_row_uploaders[index] = uploader
                             new_row_durations[index] = duration
                         else:
-                            print("ERROR NO DATA")
-                            new_row_titles[index] = "VIDEO PRIVATE"
-                            new_row_uploaders[index] = "VIDEO PRIVATE"
-                            new_row_durations[index] = "VIDEO PRIVATE"
+                            print("ERROR: VIDEO UNAVAILABLE; NO DATA")
+                            new_row_titles[index] = cell
+                            new_row_uploaders[index] = cell
+                            new_row_durations[index] = cell
                 else:
                     if data_pulling.contains_accepted_domain(
                         cell


### PR DESCRIPTION
- Previously, whenever video data was unable to be retrieved due to unavailability (due to being privated/deleted/terminated/etc.) the video's title, duration, and uploader cells would be replaced with the string "VIDEO PRIVATED" 
- Now, the cells are simply the video link. 
- Also added a "Processing Completed" popup window once the program finishes doing it's thang. 