### PR TITLE
Add URL when video data missing, newline fix

### DIFF
--- a/classes/exceptions.py
+++ b/classes/exceptions.py
@@ -1,4 +1,4 @@
-# TODO: Deprecate when modules are removed
+# TODO: Deprecate `GetVideoMetadataError` class when modules are removed
 class GetVideoMetadataError(Exception):
     pass
 
@@ -22,6 +22,14 @@ class FetchRequestError(Exception):
 class FetchParseError(Exception):
     """Raised when an API request succeeds, but the resulting response can't be
     parsed into video data."""
+
+    pass
+
+
+class SchemaValidationError(Exception):
+    """Raised when data doesn't match the expected schema; eg. a video that has
+    no title attribute. This usually indicates that a fetch service needs to be
+    updated to provide the expected data."""
 
     pass
 

--- a/classes/fetch_services.py
+++ b/classes/fetch_services.py
@@ -14,7 +14,7 @@ from classes.exceptions import FetchRequestError, FetchParseError, VideoUnavaila
 class YouTubeFetchService:
     """Fetch service for YouTube video data. Requires a YouTube Data API key."""
 
-    def __init__(self, api_key: str, do_build_service: bool=True):
+    def __init__(self, api_key: str, do_build_service: bool = True):
         # Create the YouTube Data API service.
         if do_build_service:
             self.yt_service = build("youtube", "v3", developerKey=api_key)

--- a/classes/fetch_services.py
+++ b/classes/fetch_services.py
@@ -14,14 +14,15 @@ from classes.exceptions import FetchRequestError, FetchParseError, VideoUnavaila
 class YouTubeFetchService:
     """Fetch service for YouTube video data. Requires a YouTube Data API key."""
 
-    def __init__(self, api_key: str):
+    def __init__(self, api_key: str, do_build_service: bool=True):
         # Create the YouTube Data API service.
-        self.yt_service = build("youtube", "v3", developerKey=api_key)
+        if do_build_service:
+            self.yt_service = build("youtube", "v3", developerKey=api_key)
 
     def extract_video_id(self, url: str) -> str:
         """Given a YouTube video URL, extract the video id from it."""
 
-        video_id_regex = r"(?:\?v=|/embed/|/watch\?v=|/youtu.be/)([a-zA-Z0-9_-]+)"
+        video_id_regex = r"(?:\?v=|/embed/|/watch\?v=|/youtu.be/|live/)([a-zA-Z0-9_-]+)"
 
         video_id_match = re.search(video_id_regex, url)
 

--- a/classes/fetcher.py
+++ b/classes/fetcher.py
@@ -66,7 +66,7 @@ class Fetcher:
         cache_key = self.generate_cache_key(service_name, url)
         cached_response = None
         if self.cache is not None and self.cache.has(cache_key):
-            self.print(f"[cache]: Response for <{url}> loaded from cache.", "suc")
+            self.print(f"[cache]: Response for {url} loaded from cache.", "suc")
             cached_response = self.cache.get(cache_key)
 
         if cached_response is not None:
@@ -75,7 +75,7 @@ class Fetcher:
             # Request phase: Use a capable service to request video data
             # from the URL.
             try:
-                self.print(f"[{service_name}]: Requesting data from <{url}>...")
+                self.print(f"[{service_name}]: Requesting data from {url}...")
                 response = service.request(url)
             except Exception as e:
                 self.print(f"[{service_name}]: Request error: {e}]", "err")
@@ -95,9 +95,10 @@ class Fetcher:
             try:
                 self.cache.set(cache_key, response)
             except TypeError as e:
-                # If we can't cache the response, give a warning, but continue.
+                # If we can't cache the response (because the response isn't
+                # JSON-serializable), give a warning, but continue.
                 self.print(
-                    f'[cache]: Unable to cache response from URL "{url}"; {e}', "err"
+                    f'[cache]: Unable to cache response from URL {url}; {e}', "err"
                 )
 
         return parsed_data

--- a/classes/fetcher.py
+++ b/classes/fetcher.py
@@ -98,7 +98,7 @@ class Fetcher:
                 # If we can't cache the response (because the response isn't
                 # JSON-serializable), give a warning, but continue.
                 self.print(
-                    f'[cache]: Unable to cache response from URL {url}; {e}', "err"
+                    f"[cache]: Unable to cache response from URL {url}; {e}", "err"
                 )
 
         return parsed_data

--- a/functions/voting.py
+++ b/functions/voting.py
@@ -7,7 +7,11 @@ from pytz import timezone
 from functions.date import parse_votes_csv_timestamp, format_votes_csv_timestamp
 from classes.voting import Ballot, Vote, Video
 from classes.fetcher import Fetcher
-from classes.exceptions import VideoUnavailableError, UnsupportedHostError, SchemaValidationError
+from classes.exceptions import (
+    VideoUnavailableError,
+    UnsupportedHostError,
+    SchemaValidationError,
+)
 
 
 def load_votes_csv(csv_file_path_str: str) -> list[Ballot]:
@@ -96,7 +100,9 @@ def fetch_video_data_for_ballots(
             # service needs updating to provide all required fields.
             missing_fields = validate_video_data(data)
             if len(missing_fields) > 0:
-                raise SchemaValidationError(f'Error when validating video data for URL "{url}"; the following fields are missing: {", ".join(missing_fields)}')
+                raise SchemaValidationError(
+                    f'Error when validating video data for URL "{url}"; the following fields are missing: {", ".join(missing_fields)}'
+                )
 
             videos[vote.url] = video
 
@@ -107,10 +113,11 @@ def validate_video_data(data: dict) -> list[str]:
     """Check the given dictionary of video data and return a list of missing
     fields, if any. This helps ensure the fields we're interested in are always
     available."""
-    required_fields = ['title', 'uploader', 'upload_date', 'duration']
+    required_fields = ["title", "uploader", "upload_date", "duration"]
     missing_fields = [field for field in required_fields if field not in data]
 
     return missing_fields
+
 
 def generate_annotated_csv_data(
     ballots: list[Ballot], videos: dict[str, Video]

--- a/main.py
+++ b/main.py
@@ -221,7 +221,7 @@ def run_checks():
     inf(f"Writing annotated ballot data...")
     output_csv_data = generate_annotated_csv_data(ballots, videos)
     output_csv_path = Path(output_csv_path_str)
-    with output_csv_path.open("w", encoding="utf-8") as output_csv_file:
+    with output_csv_path.open("w", newline="", encoding="utf-8") as output_csv_file:
         output_csv_writer = csv.writer(output_csv_file)
         output_csv_writer.writerows(output_csv_data)
 

--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 import unittest
 from tests.classes.fetcher import TestFetcher
+from tests.classes.fetch_services import TestFetchServices
 from tests.functions.voting import TestFunctionsVoting
 from tests.functions.date import TestFunctionsDate
 from tests.functions.video_rules import TestFunctionsVideoRules

--- a/tests/classes/fetch_services.py
+++ b/tests/classes/fetch_services.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+from classes.fetch_services import YouTubeFetchService
+
+
+class TestFetchServices(TestCase):
+    def test_YouTubeFetchService(self):
+        service = YouTubeFetchService('API_KEY', False)
+
+        # Regular YouTube URL
+        url = 'https://www.youtube.com/watch?v=9RT4lfvVFhA'
+        self.assertTrue(service.can_fetch(url))
+        self.assertEqual('9RT4lfvVFhA', service.extract_video_id(url))
+
+        # Shortened YouTube URL
+        url = 'https://youtu.be/9RT4lfvVFhA'
+        self.assertTrue(service.can_fetch(url))
+        self.assertEqual('9RT4lfvVFhA', service.extract_video_id(url))
+
+        # Shortened YouTube URL with social tracking identifier
+        url = 'https://youtu.be/9RT4lfvVFhA?si=WXC57zYboHEsKd-C'
+        self.assertTrue(service.can_fetch(url))
+        self.assertEqual('9RT4lfvVFhA', service.extract_video_id(url))
+
+        # Livestream URL
+        url = 'https://www.youtube.com/live/Q8k4UTf8jiI'
+        self.assertTrue(service.can_fetch(url))
+        self.assertEqual('Q8k4UTf8jiI', service.extract_video_id(url))
+
+        # Livestream URL with social tracking identifier
+        url = 'https://www.youtube.com/live/Q8k4UTf8jiI?si=Ohm26zie1Gp07sBV'
+        self.assertTrue(service.can_fetch(url))
+        self.assertEqual('Q8k4UTf8jiI', service.extract_video_id(url))
+
+        # Non-YouTube URL
+        url = 'https://pony.tube/w/2FCj5YvmdHy8AC2hkEbc9i'
+        self.assertFalse(service.can_fetch(url))
+        self.assertEqual(None, service.extract_video_id(url))

--- a/tests/classes/fetch_services.py
+++ b/tests/classes/fetch_services.py
@@ -4,34 +4,34 @@ from classes.fetch_services import YouTubeFetchService
 
 class TestFetchServices(TestCase):
     def test_YouTubeFetchService(self):
-        service = YouTubeFetchService('API_KEY', False)
+        service = YouTubeFetchService("API_KEY", False)
 
         # Regular YouTube URL
-        url = 'https://www.youtube.com/watch?v=9RT4lfvVFhA'
+        url = "https://www.youtube.com/watch?v=9RT4lfvVFhA"
         self.assertTrue(service.can_fetch(url))
-        self.assertEqual('9RT4lfvVFhA', service.extract_video_id(url))
+        self.assertEqual("9RT4lfvVFhA", service.extract_video_id(url))
 
         # Shortened YouTube URL
-        url = 'https://youtu.be/9RT4lfvVFhA'
+        url = "https://youtu.be/9RT4lfvVFhA"
         self.assertTrue(service.can_fetch(url))
-        self.assertEqual('9RT4lfvVFhA', service.extract_video_id(url))
+        self.assertEqual("9RT4lfvVFhA", service.extract_video_id(url))
 
         # Shortened YouTube URL with social tracking identifier
-        url = 'https://youtu.be/9RT4lfvVFhA?si=WXC57zYboHEsKd-C'
+        url = "https://youtu.be/9RT4lfvVFhA?si=WXC57zYboHEsKd-C"
         self.assertTrue(service.can_fetch(url))
-        self.assertEqual('9RT4lfvVFhA', service.extract_video_id(url))
+        self.assertEqual("9RT4lfvVFhA", service.extract_video_id(url))
 
         # Livestream URL
-        url = 'https://www.youtube.com/live/Q8k4UTf8jiI'
+        url = "https://www.youtube.com/live/Q8k4UTf8jiI"
         self.assertTrue(service.can_fetch(url))
-        self.assertEqual('Q8k4UTf8jiI', service.extract_video_id(url))
+        self.assertEqual("Q8k4UTf8jiI", service.extract_video_id(url))
 
         # Livestream URL with social tracking identifier
-        url = 'https://www.youtube.com/live/Q8k4UTf8jiI?si=Ohm26zie1Gp07sBV'
+        url = "https://www.youtube.com/live/Q8k4UTf8jiI?si=Ohm26zie1Gp07sBV"
         self.assertTrue(service.can_fetch(url))
-        self.assertEqual('Q8k4UTf8jiI', service.extract_video_id(url))
+        self.assertEqual("Q8k4UTf8jiI", service.extract_video_id(url))
 
         # Non-YouTube URL
-        url = 'https://pony.tube/w/2FCj5YvmdHy8AC2hkEbc9i'
+        url = "https://pony.tube/w/2FCj5YvmdHy8AC2hkEbc9i"
         self.assertFalse(service.can_fetch(url))
         self.assertEqual(None, service.extract_video_id(url))

--- a/tests/functions/voting.py
+++ b/tests/functions/voting.py
@@ -4,6 +4,7 @@ from pytz import timezone
 from functions.voting import (
     process_votes_csv,
     process_votes_csv_row,
+    validate_video_data,
     generate_annotated_csv_data,
 )
 from classes.voting import Ballot, Vote, Video
@@ -106,6 +107,35 @@ class TestFunctionsVoting(TestCase):
         self.assertEqual("https://example.com/6", ballot.votes[5].url)
         self.assertEqual("https://example.com/7", ballot.votes[6].url)
 
+
+    def test_validate_video_data(self):
+        data = {
+            'title': 'Example Video 1',
+            'uploader': 'Example Uploader',
+            'upload_date': datetime(2024, 4, 1, 9, 0, 0),
+            'duration': 300
+        }
+        missing_fields = validate_video_data(data)
+        self.assertEqual(0, len(missing_fields))
+
+        data = {
+            'uploader': 'Example Uploader',
+            'upload_date': datetime(2024, 4, 1, 9, 0, 0),
+            'duration': 300
+        }
+        missing_fields = validate_video_data(data)
+        self.assertEqual(1, len(missing_fields))
+        self.assertEqual('title', missing_fields[0])
+
+        data = {}
+        missing_fields = validate_video_data(data)
+        self.assertEqual(4, len(missing_fields))
+        self.assertEqual('title', missing_fields[0])
+        self.assertEqual('uploader', missing_fields[1])
+        self.assertEqual('upload_date', missing_fields[2])
+        self.assertEqual('duration', missing_fields[3])
+
+
     def test_generate_annotated_csv_data(self):
         ballots = [
             # Ballot with 10 votes, some annotated
@@ -156,7 +186,8 @@ class TestFunctionsVoting(TestCase):
             "https://example.com/7": Video({"title": "Example Video 7"}),
             "https://example.com/8": Video({"title": "Example Video 8"}),
             "https://example.com/9": Video({"title": "Example Video 9"}),
-            "https://example.com/10": Video({"title": "Example Video 10"}),
+            # Video with no data
+            "https://example.com/10": Video(),
         }
         ballots[0].votes[0].annotations.add("VIDEO TOO OLD")
         ballots[0].votes[0].annotations.add("VIDEO TOO SHORT")
@@ -197,7 +228,9 @@ class TestFunctionsVoting(TestCase):
         self.assertEqual("", csv_rows[1][17])
         self.assertEqual("Example Video 9", csv_rows[1][18])
         self.assertEqual("", csv_rows[1][19])
-        self.assertEqual("Example Video 10", csv_rows[1][20])
+        # For the last row, since the video has no data, by convention the vote
+        # URL should be included instead.
+        self.assertEqual("https://example.com/10", csv_rows[1][20])
         self.assertEqual("", csv_rows[1][21])
 
         # Row 2

--- a/tests/functions/voting.py
+++ b/tests/functions/voting.py
@@ -107,34 +107,32 @@ class TestFunctionsVoting(TestCase):
         self.assertEqual("https://example.com/6", ballot.votes[5].url)
         self.assertEqual("https://example.com/7", ballot.votes[6].url)
 
-
     def test_validate_video_data(self):
         data = {
-            'title': 'Example Video 1',
-            'uploader': 'Example Uploader',
-            'upload_date': datetime(2024, 4, 1, 9, 0, 0),
-            'duration': 300
+            "title": "Example Video 1",
+            "uploader": "Example Uploader",
+            "upload_date": datetime(2024, 4, 1, 9, 0, 0),
+            "duration": 300,
         }
         missing_fields = validate_video_data(data)
         self.assertEqual(0, len(missing_fields))
 
         data = {
-            'uploader': 'Example Uploader',
-            'upload_date': datetime(2024, 4, 1, 9, 0, 0),
-            'duration': 300
+            "uploader": "Example Uploader",
+            "upload_date": datetime(2024, 4, 1, 9, 0, 0),
+            "duration": 300,
         }
         missing_fields = validate_video_data(data)
         self.assertEqual(1, len(missing_fields))
-        self.assertEqual('title', missing_fields[0])
+        self.assertEqual("title", missing_fields[0])
 
         data = {}
         missing_fields = validate_video_data(data)
         self.assertEqual(4, len(missing_fields))
-        self.assertEqual('title', missing_fields[0])
-        self.assertEqual('uploader', missing_fields[1])
-        self.assertEqual('upload_date', missing_fields[2])
-        self.assertEqual('duration', missing_fields[3])
-
+        self.assertEqual("title", missing_fields[0])
+        self.assertEqual("uploader", missing_fields[1])
+        self.assertEqual("upload_date", missing_fields[2])
+        self.assertEqual("duration", missing_fields[3])
 
     def test_generate_annotated_csv_data(self):
         ballots = [


### PR DESCRIPTION
* Fixed issue where URL wasn't being included in output CSV when video data is missing
* Fixed newline bug when writing output CSV on Windows systems
* Updated YouTube fetch service to recognize livestream links (`/live/` in URL)
* Added validation for video data objects to ensure data integrity
* Updated unit tests