### PR TITLE
Add whitelist for known uploaders

### DIFF
--- a/classes/fetch_services.py
+++ b/classes/fetch_services.py
@@ -126,7 +126,7 @@ class YtDlpFetchService:
 
         video_data = {
             "title": response.get("title"),
-            "uploader": response.get("uploader"),
+            "uploader": response.get("channel"),
             "upload_date": upload_date,
             "duration": response.get("duration"),
         }

--- a/classes/ui.py
+++ b/classes/ui.py
@@ -9,7 +9,7 @@ class CSVEditor(tk.Frame):
     """CSV editor UI."""
 
     def __init__(self, master):
-        super().__init__(master, borderwidth=1, relief='sunken')
+        super().__init__(master, borderwidth=1, relief="sunken")
 
         self.file_path = tk.StringVar()
         self.data = []
@@ -20,12 +20,16 @@ class CSVEditor(tk.Frame):
         """Create and lay out the various UI widgets required by the CSV editor."""
         # File select button and save button
         self.buttons_frame = tk.Frame(self)
-        self.load_csv_button = ttk.Button(self.buttons_frame, text="📁 Load CSV...", command=self.browse_file)
+        self.load_csv_button = ttk.Button(
+            self.buttons_frame, text="📁 Load CSV...", command=self.browse_file
+        )
         self.save_button = ttk.Button(
             self.buttons_frame, text="💾 Save Changes", command=self.save_changes
         )
         self.load_processed_csv_button = ttk.Button(
-            self.buttons_frame, text="📄 Load Processed CSV", command=self.load_processed_csv
+            self.buttons_frame,
+            text="📄 Load Processed CSV",
+            command=self.load_processed_csv,
         )
 
         self.load_csv_button.grid(row=0, column=0)
@@ -96,7 +100,7 @@ class CSVEditor(tk.Frame):
             widget.destroy()
 
         label_colors = {
-            'orange': [
+            "orange": [
                 "[SIMILARITY DETECTED",
                 "[DUPLICATE CREATOR]",
                 "[VIDEO TOO OLD]",
@@ -104,12 +108,12 @@ class CSVEditor(tk.Frame):
                 "[VIDEO MAYBE TOO SHORT]",
                 "[NOT WHITELISTED]",
             ],
-            'red': [
+            "red": [
                 "[5 CHANNEL RULE]",
                 "[UNSUPPORTED HOST]",
                 "[VIDEO TOO SHORT]",
                 "[BLACKLISTED]",
-            ]
+            ],
         }
 
         # Display CSV data
@@ -120,7 +124,7 @@ class CSVEditor(tk.Frame):
                 entry.insert(tk.END, value)
                 # Cell color defaults to green.
                 entry_fg_color = "green"
-                
+
                 # Set the cell color depending on whether the cell value
                 # contains (or partially contains) any of a given set of labels.
                 # If a cell contains orange and red labels, red is given
@@ -133,7 +137,6 @@ class CSVEditor(tk.Frame):
 
                 entry.config(fg=entry_fg_color)
 
-
     def save_changes(self):
         """Save any text changes made via the UI to the CSV file (that was
         selected by pressing the "Load CSV..." button)."""
@@ -144,9 +147,10 @@ class CSVEditor(tk.Frame):
                 )[0]
                 self.data[row_idx][col_idx] = entry_widget.get()
 
-
-        if self.file_path.get() == '':
-            tk.messagebox.showinfo("Error", "No CSV file loaded. Please load a CSV file first.")
+        if self.file_path.get() == "":
+            tk.messagebox.showinfo(
+                "Error", "No CSV file loaded. Please load a CSV file first."
+            )
             return
 
         # Save the changes

--- a/data/uploader_whitelist.txt
+++ b/data/uploader_whitelist.txt
@@ -1,0 +1,396 @@
+2ManySnacks
+2Snacks
+4everfreebrony
+abwaschbar
+Ace Attorney: Elements of Justice
+Acinonyx Jubatus
+ACLP Films
+ACRacebest
+adamtheamazing64
+adecoy95
+Adrian Genin
+AgrolChannel
+Aj's Film Co.
+Alan Crytex
+Alekc233
+alfa995
+Alligator Tub Productions
+AlStiff
+Alumx
+Amante Animations
+AnimatedJames
+AnontheAnon Inc.
+Antony C
+Applemations FiM
+Argodaemon
+Artist Creations Pictures, Inc.
+Ava CreeperZone
+AVbyte
+AxelThePony
+banquo0
+BAST Brushie
+Batsy
+bb-panzu
+Bench Thief Productions
+BenzAyngCup
+BGM, Pony Degeneracy
+Biscuit Bites
+Black Gryph0n
+Black Sunflower
+Bluebro
+BogyleBronies
+BrainstormAlex
+Brandon the Brony Pony
+Brittney Ackerman
+BronyCon
+BronyDanceParty
+BronyMike
+Bronytoons
+BrutalWeather
+BVids
+CanaleDoppiaggi
+Cantersoft
+CaptainHoers
+CarbonMaestro
+Catsuhako
+Chicken Cake
+Christian Cerda
+Cinematic Productions
+Claire Margaret Corlett
+Clipper Anon
+Coconeru
+Cole Donnerstag
+Corpse Run Comics
+Cosmia's Stash
+CreatorOfPony
+Cross Guard
+Crossline Animator
+Crowne Prince
+Cxcd
+D0ubleRainb0wDash Animations
+Dabu197393
+DabuXian
+Daddystino The Guy
+Dark Gloones
+DarkStar
+Dasha Moone
+daspacepony
+davee MLP
+Dawn Somewhere
+Dazzl
+ddrkreature
+DeadlyComics
+DEATH BATTLE!
+Derek pony
+Derpy Hooves
+derpylives
+DerpyTwizzle
+DJAelxs
+DoctorWhy
+DoodledPony
+Dori-to Pony
+doubleWbrothers
+Draft The Filmmaker
+DragonCurse
+Dragonfoxgirl
+dragonv0942
+DRWolf001
+DubstepleeVids
+Duo Cartoonist
+Dustykatt Rhoades
+DWK
+DXIndustriesInc
+EDplus777
+EG Studios
+EMosite CC
+EqAmRd
+Equestria Collabs
+EverFree Team
+Everlasting Joy
+Evershade
+Excal! [ 20excalibur07 ]
+EzeCoyote
+Fantasy Blade
+Farionelle
+Feedsy
+felicitea
+Ferexes
+Flashgen
+FlashQuatsch
+FlippinDingDong
+Flowerzinc
+Fluffle Puff
+Flutter525
+FluttershyElsa
+FOB Equestria
+ForgaLorga
+Fritzy Magpies!
+GalaCon
+Galaxyart
+Gamerboy
+GatorGoatJohnny
+GD Studio
+Gentlecolt
+GinjaNinjaOwO
+Glistening Dawn Productions
+Glitzer
+Gravity
+Greyskee
+HailBlitz Animation
+Harlen EAP
+Harmony Studios
+Herostrain
+Holman Animations
+hotdiggedydemon
+Humphrey Dumpty
+Ian Mitchell
+ICanSeeYourShed
+ILoveKimPossibleAlot
+IMShadow007
+Ink Potts
+isaiahdjkim
+itsannachloem
+Ivory
+Izeer PMV's
+Jack DC 93
+JackDC93
+JackleApp
+Jacob Kitts
+JakeWhyman
+Jaltoid
+James Lee
+Jan Animation Studios
+JeffKyler14
+Jenny Nicholson
+JHaller
+Jimmy Lee
+joshscorcher
+JuiceboxAlvin
+Jynx Animated
+Kaciekk
+kanashiipanda
+Katsuhono
+Kem
+Khuzang
+Kid Wizard
+killme2paza
+klystron2010
+Knick Knack
+Krecker
+Krunkidile
+Kuri-Karu
+Kybdi
+LAndy Pommel
+Languorld
+Larkin
+Lemon Studio Animation
+Lerovun
+Letupita725HD★
+LFØ
+Liftlok
+Lightning Bliss
+Limey Lassen
+LittleshyFiM
+LizzieBiz
+llshockedll
+loljailbait
+Loljailbait
+LuckyDragon
+LUMO_Xu
+Lunar Cakez
+Lunar Evening
+L.Y.R.A. Animations
+MadameLeFlour
+Mad Munchkin
+Magpiepony
+Makaryo
+Malathrom
+Mare Fair
+MarkandFlops
+Mayde
+MicTheMicrophoneZero
+MidnightAurora
+Midnight Wave
+Minty Root
+MisterDavie
+MKogwheel
+MLP Fever
+mlpfimguy
+mlp Lights™
+MLP-Silver-Quill
+Moonmart4u
+Mooseboy018
+MoreStar
+MrDeLoop
+Mr KupKake
+Mr. ShinyObject
+MuseScript
+MV
+MyLittleCollabs
+MysteryBen27
+NCHProductions
+Nechi
+NekoSnicker
+Nieve Helada
+NightFalls Studios
+No1c00l
+nomorethan9
+Nutrafin
+NyLab
+ObisamAnimations
+ocarinaplaya
+OhPonyBoy
+Okusheny
+olibacon
+OmegaOzone
+Optic Spectrum
+Para Collaboration
+PartyGrunt
+Pearmare Animation
+PenguinPotential
+Perdue “PerdueShield” Shield
+Perdue Shield
+Piemations
+Pikapetey Animations
+PinkiePieSwear
+Pinkie Rose
+PMV World
+Ponies At Dawn
+Ponies In Reverse
+Ponies With Pockets Productions
+PonyTimeRush Collab
+Princely
+PrinceWhateverer
+Prosper58
+PWaaMLPfim
+RabiesBun
+rabiesx86
+RACA PINANG
+Racecarghost
+RaenyVisualz
+Rainbott
+RainParrot
+Ralek-Arts
+Random Encounters
+RaptorNX01
+Raycord Disman
+RemViolet
+Rina-chan
+Robin Jacks
+Rock29Roll [Comic Auzi]
+Róger Capellán
+Round Trip
+rsmv2you
+RUN - NPZ
+Saberspark
+Sakojima5555
+Sawtooth Waves
+SayMaxWell
+Scootertrix Studios
+Scraton Music Official
+Scribbler Productions
+Scyrina
+Sedaheht
+SFS Animation
+SgtScrubnoob
+ShadesofEverfree
+Shawn Keller
+Sherclop Pones
+SherclopPones
+shgurr
+ShironCruz
+shiropoint
+SilkAMV
+SinclairDuGore
+Skaijo
+Skill:Draw
+SkyTails
+SlyBot Animation
+SlyVox
+Small Owl
+smile信仰
+Snapai
+Snivian Moon
+SnowT
+Soniccrew128
+Space Oddpony
+Sparkle Animation Studio
+SparrowFae
+Squeak Anon
+SSJshadowX
+STANN.co
+StasySolitude
+StormXF3
+Studio Cinemagic
+Stunthead
+SubZeroVector
+Sunbirth
+Sweetie Bot 2560
+TechPony
+TehJadeh
+TheAcleps
+The Anonymator
+The Brony Notion
+The Collaboratory
+TheDuckPone
+TheeLinker
+TheEmpty10
+the faked reel
+The G Man
+TheInvertedShadow
+TheLightLeavesThee
+The Living Tombstone
+TheLostNarrator
+TheOtherPony
+TheRedAceOfSpades
+TheSamStudio
+The Sfm Corner
+thorhajo
+tiarawhy
+TioRafaJP2
+TJ Pones
+T.L. Peng
+T.L. Peng 绵软绒辉
+TobbyMLP
+Tom10320
+TommyXe
+Tootsie4ever
+Toshimatsu
+ToucanLDM
+Tridashie
+Tweek Studio Animation
+Twilie Atkins
+Umby
+Unanimous Delivers
+Valinye
+VannaMelon
+Vasega old cinema
+Vilord Studio
+Vinson Visions
+Viraus2
+Viva Reverie
+VocalScorePony
+Vylet Pony
+WarpOut
+Wasteland Productions
+WatchPony
+Weegygreen2
+WhiteHawke
+Wooshy
+Wubby Dubby
+Xaniyo
+Yaasho
+Yaplap
+YeCrotMLP
+Yoshi Greenwater
+Yudhaikeledai
+Yunlong Chen
+Zachary Rich
+zeffdakilla
+Zeldendorf
+ZephyrStar
+Zeurel
+zyh黑风
+☆НеаДекват Animations☆
+Синдикат Брони
+斯朗Shiron

--- a/functions/ballot_rules.py
+++ b/functions/ballot_rules.py
@@ -28,6 +28,18 @@ def check_blacklisted_ballots(ballots: list[Ballot], videos: dict[str, Video]):
             if video.annotations.has("BLACKLISTED"):
                 vote.annotations.add("BLACKLISTED")
 
+def check_non_whitelisted_ballots(ballots: list[Ballot], videos: dict[str, Video]):
+    """Given a list of ballots and a dictionary of annotated videos indexed by
+    URL, annotate any votes for videos which were not found on the whitelist.
+    (This makes it easier to spot new or unknown creators during a manual
+    review).
+    """
+    for ballot in ballots:
+        for vote in ballot.votes:
+            video = videos[vote.url]
+            if video.annotations.has("NOT WHITELISTED"):
+                vote.annotations.add("NOT WHITELISTED")
+
 
 def check_ballot_upload_dates(ballots: list[Ballot], videos: dict[str, Video]):
     """Given a list of ballots and a dictionary of annotated videos indexed by

--- a/functions/ballot_rules.py
+++ b/functions/ballot_rules.py
@@ -28,6 +28,7 @@ def check_blacklisted_ballots(ballots: list[Ballot], videos: dict[str, Video]):
             if video.annotations.has("BLACKLISTED"):
                 vote.annotations.add("BLACKLISTED")
 
+
 def check_non_whitelisted_ballots(ballots: list[Ballot], videos: dict[str, Video]):
     """Given a list of ballots and a dictionary of annotated videos indexed by
     URL, annotate any votes for videos which were not found on the whitelist.

--- a/functions/video_rules.py
+++ b/functions/video_rules.py
@@ -1,16 +1,29 @@
-"""Rule checks for videos."""
+"""Rule checks for videos. These functions check videos for validity and
+annotate any that fail the tests. Note that this is different from annotating a
+_vote_ for a video, which happens in `functions/ballot_rules.py`. Some of the
+vote checks rely on videos having been checked and annotated first."""
 
 from datetime import datetime
 from classes.voting import Video
 
 
-def check_blacklist(videos: list[Video], blacklisted_uploaders: list[str]):
+def check_uploader_blacklist(videos: list[Video], blacklisted_uploaders: list[str]):
     """Check the given list of videos against a list of blacklisted uploaders.
     Annotate any videos with a blacklisted uploader.
     """
     for video in videos:
         if video.data["uploader"] in blacklisted_uploaders:
             video.annotations.add("BLACKLISTED")
+
+
+def check_uploader_whitelist(videos: list[Video], whitelisted_uploaders: list[str]):
+    """Check the given list of videos against a list of whitelisted uploaders.
+    Annotate any videos whose uploader is NOT on the whitelist. (This makes it
+    easier to spot new or unknown creators during a manual review).
+    """
+    for video in videos:
+        if video.data["uploader"] not in whitelisted_uploaders:
+            video.annotations.add("NOT WHITELISTED")
 
 
 def check_upload_date(videos: list[Video], month_date: datetime):

--- a/main.py
+++ b/main.py
@@ -14,7 +14,12 @@ from functions.voting import (
     generate_annotated_csv_data,
 )
 from functions.date import get_preceding_month_date, is_date_between, get_month_bounds
-from functions.video_rules import check_uploader_blacklist, check_uploader_whitelist, check_upload_date, check_duration
+from functions.video_rules import (
+    check_uploader_blacklist,
+    check_uploader_whitelist,
+    check_upload_date,
+    check_duration,
+)
 from functions.ballot_rules import (
     check_duplicates,
     check_blacklisted_ballots,
@@ -271,10 +276,12 @@ entry_var = tk.StringVar()
 entry = ttk.Entry(main_frame, textvariable=entry_var)
 entry.pack(padx=10, pady=10)
 
-browse_button = ttk.Button(main_frame, text="📁 Load Votes CSV...", command=browse_file_csv)
+browse_button = ttk.Button(
+    main_frame, text="📁 Load Votes CSV...", command=browse_file_csv
+)
 browse_button.pack(pady=10)
 
-checks_frame = tk.LabelFrame(main_frame, text='Checks')
+checks_frame = tk.LabelFrame(main_frame, text="Checks")
 # Create checkboxes and the variables bound to them.
 check_labels = {
     "duplicate": "Duplicate Check",
@@ -295,12 +302,14 @@ check_checkboxes = {
 
 for row, key in enumerate(check_checkboxes):
     checkbox = check_checkboxes[key]
-    checkbox.grid(row=row, sticky='W', padx=10)
+    checkbox.grid(row=row, sticky="W", padx=10)
 
 checks_frame.pack(pady=20)
 
 debug_var = tk.BooleanVar()
-debug_checkbox = ttk.Checkbutton(main_frame, text="Enable Debug Files (Broken LOL)", variable=debug_var)
+debug_checkbox = ttk.Checkbutton(
+    main_frame, text="Enable Debug Files (Broken LOL)", variable=debug_var
+)
 debug_checkbox.pack()
 
 run_button = ttk.Button(main_frame, text="📜 Run Checks", command=run_checks)

--- a/main.py
+++ b/main.py
@@ -14,10 +14,11 @@ from functions.voting import (
     generate_annotated_csv_data,
 )
 from functions.date import get_preceding_month_date, is_date_between, get_month_bounds
-from functions.video_rules import check_blacklist, check_upload_date, check_duration
+from functions.video_rules import check_uploader_blacklist, check_uploader_whitelist, check_upload_date, check_duration
 from functions.ballot_rules import (
     check_duplicates,
     check_blacklisted_ballots,
+    check_non_whitelisted_ballots,
     check_ballot_upload_dates,
     check_ballot_video_durations,
     check_fuzzy,
@@ -46,6 +47,7 @@ CONFIG = {
     "paths": {
         "icon": "images/icon.ico",
         "blacklist": "data/blacklist.txt",
+        "whitelist": "data/uploader_whitelist.txt",
         "output": "outputs/processed.csv",
     },
     "fuzzy_similarity_threshold": 80,
@@ -172,7 +174,12 @@ def run_checks():
     inf("* Checking for videos from blacklisted uploaders...")
     blacklist_path = Path(CONFIG["paths"]["blacklist"])
     blacklist = [line.strip() for line in blacklist_path.open()]
-    check_blacklist(videos_with_data.values(), blacklist)
+    check_uploader_blacklist(videos_with_data.values(), blacklist)
+
+    inf("* Checking for videos from whitelisted uploaders...")
+    whitelist_path = Path(CONFIG["paths"]["whitelist"])
+    whitelist = [line.strip() for line in whitelist_path.open()]
+    check_uploader_whitelist(videos_with_data.values(), whitelist)
 
     inf(f"* Checking video upload dates...")
     check_upload_date(videos_with_data.values(), upload_month_date)
@@ -194,6 +201,10 @@ def run_checks():
     if do_check("blacklist"):
         inf("* Checking for votes for blacklisted videos...")
         check_blacklisted_ballots(ballots, videos)
+
+    if do_check("whitelist"):
+        inf("* Checking for votes for non-whitelisted videos...")
+        check_non_whitelisted_ballots(ballots, videos)
 
     if do_check("upload_date"):
         inf("* Checking for votes for videos with invalid upload dates...")
@@ -260,14 +271,15 @@ entry_var = tk.StringVar()
 entry = ttk.Entry(main_frame, textvariable=entry_var)
 entry.pack(padx=10, pady=10)
 
-browse_button = ttk.Button(main_frame, text="Browse", command=browse_file_csv)
+browse_button = ttk.Button(main_frame, text="📁 Load Votes CSV...", command=browse_file_csv)
 browse_button.pack(pady=10)
 
+checks_frame = tk.LabelFrame(main_frame, text='Checks')
 # Create checkboxes and the variables bound to them.
 check_labels = {
-    "debug": "Enable Debug Files (Broken LOL)",
     "duplicate": "Duplicate Check",
     "blacklist": "Blacklist Check",
+    "whitelist": "Whitelist Check",
     "upload_date": "Upload Date Check",
     "duration": "Duration Check",
     "fuzzy": "Fuzzy Check",
@@ -276,23 +288,23 @@ check_labels = {
 }
 
 check_vars = {key: tk.BooleanVar(value=True) for key in check_labels}
-
-# Disable the debug checkbox by default.
-check_vars["debug"] = tk.BooleanVar()
-
-checkboxes = {
-    key: ttk.Checkbutton(main_frame, text=check_labels[key], variable=check_vars[key])
+check_checkboxes = {
+    key: ttk.Checkbutton(checks_frame, text=check_labels[key], variable=check_vars[key])
     for key in check_labels
 }
 
-for key, checkbox in checkboxes.items():
-    if key == "debug":
-        checkbox.pack(pady=40)
-    else:
-        checkbox.pack()
+for row, key in enumerate(check_checkboxes):
+    checkbox = check_checkboxes[key]
+    checkbox.grid(row=row, sticky='W', padx=10)
 
-run_button = ttk.Button(main_frame, text="Run Checks", command=run_checks)
-run_button.pack()
+checks_frame.pack(pady=20)
+
+debug_var = tk.BooleanVar()
+debug_checkbox = ttk.Checkbutton(main_frame, text="Enable Debug Files (Broken LOL)", variable=debug_var)
+debug_checkbox.pack()
+
+run_button = ttk.Button(main_frame, text="📜 Run Checks", command=run_checks)
+run_button.pack(pady=20)
 
 csv_editor = CSVEditor(main_frame)  # Editor main frame
 csv_editor.pack()

--- a/tests/functions/ballot_rules.py
+++ b/tests/functions/ballot_rules.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 from functions.ballot_rules import (
     check_duplicates,
     check_blacklisted_ballots,
+    check_non_whitelisted_ballots,
     check_ballot_upload_dates,
     check_ballot_video_durations,
     check_fuzzy,
@@ -432,8 +433,10 @@ class TestFunctionsBallotRules(TestCase):
         videos["https://example.com/2"].annotations.add("BLACKLISTED")
         videos["https://example.com/2"].annotations.add("VIDEO MAYBE TOO SHORT")
         videos["https://example.com/3"].annotations.add("VIDEO TOO NEW")
+        videos["https://example.com/3"].annotations.add("NOT WHITELISTED")
 
         check_blacklisted_ballots(ballots, videos)
+        check_non_whitelisted_ballots(ballots, videos)
         check_ballot_upload_dates(ballots, videos)
         check_ballot_video_durations(ballots, videos)
 
@@ -443,4 +446,5 @@ class TestFunctionsBallotRules(TestCase):
         self.assertTrue(ballots[0].votes[1].annotations.has("BLACKLISTED"))
         self.assertTrue(ballots[0].votes[1].annotations.has("VIDEO MAYBE TOO SHORT"))
         self.assertTrue(ballots[1].votes[0].annotations.has("VIDEO TOO NEW"))
+        self.assertTrue(ballots[1].votes[0].annotations.has("NOT WHITELISTED"))
         self.assertTrue(ballots[1].votes[1].annotations.has_none())

--- a/tests/functions/video_rules.py
+++ b/tests/functions/video_rules.py
@@ -1,11 +1,11 @@
 from unittest import TestCase
 from datetime import datetime
 from classes.voting import Video
-from functions.video_rules import check_blacklist, check_upload_date, check_duration
+from functions.video_rules import check_uploader_blacklist, check_uploader_whitelist, check_upload_date, check_duration
 
 
 class TestFunctionsVideoRules(TestCase):
-    def test_check_blacklist(self):
+    def test_check_uploader_blacklist(self):
         videos = [
             Video({"title": "Example Video 1", "uploader": "Sunny Starscout"}),
             Video({"title": "Example Video 2", "uploader": "LittleshyFiM"}),
@@ -17,7 +17,7 @@ class TestFunctionsVideoRules(TestCase):
 
         blacklisted_uploaders = ["LittleshyFiM", "Pipp Petals", "hawthornbunny"]
 
-        check_blacklist(videos, blacklisted_uploaders)
+        check_uploader_blacklist(videos, blacklisted_uploaders)
 
         self.assertFalse(videos[0].annotations.has("BLACKLISTED"))
         self.assertTrue(videos[1].annotations.has("BLACKLISTED"))
@@ -25,6 +25,27 @@ class TestFunctionsVideoRules(TestCase):
         self.assertTrue(videos[3].annotations.has("BLACKLISTED"))
         self.assertTrue(videos[4].annotations.has("BLACKLISTED"))
         self.assertFalse(videos[5].annotations.has("BLACKLISTED"))
+
+    def test_check_uploader_whitelist(self):
+        videos = [
+            Video({"title": "Example Video 1", "uploader": "Sunny Starscout"}),
+            Video({"title": "Example Video 2", "uploader": "Hitch Trailblazer"}),
+            Video({"title": "Example Video 3", "uploader": "Izzy Moonbow"}),
+            Video({"title": "Example Video 4", "uploader": "Zipp Storm"}),
+            Video({"title": "Example Video 5", "uploader": "Pipp Petals"}),
+            Video({"title": "Example Video 6", "uploader": "Misty Brightdawn"}),
+        ]
+
+        whitelisted_uploaders = ["Sunny Starscout", "Pipp Petals", "Misty Brightdawn"]
+
+        check_uploader_whitelist(videos, whitelisted_uploaders)
+
+        self.assertFalse(videos[0].annotations.has("NOT WHITELISTED"))
+        self.assertTrue(videos[1].annotations.has("NOT WHITELISTED"))
+        self.assertTrue(videos[2].annotations.has("NOT WHITELISTED"))
+        self.assertTrue(videos[3].annotations.has("NOT WHITELISTED"))
+        self.assertFalse(videos[4].annotations.has("NOT WHITELISTED"))
+        self.assertFalse(videos[5].annotations.has("NOT WHITELISTED"))
 
     def test_check_upload_date(self):
         videos = [

--- a/tests/functions/video_rules.py
+++ b/tests/functions/video_rules.py
@@ -1,7 +1,12 @@
 from unittest import TestCase
 from datetime import datetime
 from classes.voting import Video
-from functions.video_rules import check_uploader_blacklist, check_uploader_whitelist, check_upload_date, check_duration
+from functions.video_rules import (
+    check_uploader_blacklist,
+    check_uploader_whitelist,
+    check_upload_date,
+    check_duration,
+)
 
 
 class TestFunctionsVideoRules(TestCase):


### PR DESCRIPTION
* Added an `uploader_whitelist.txt` file containing a list of known creators, and added a new video rule which checks videos against the whitelist and annotates any votes for non-whitelisted videos. This helps to highlight new or unknown creators.
* Changed the yt-dlp fetch service to use `channel` for the uploader name, instead of `uploader` (which gives the user account of the uploader, not the channel name)
* Made some UI improvements for the main app.