### PR TITLE
Improve upload date leniency

### DIFF
--- a/functions/date.py
+++ b/functions/date.py
@@ -95,11 +95,13 @@ def get_preceding_month_date(date: datetime) -> datetime:
     return datetime(preceding_year, preceding_month, 1, tzinfo=date.tzinfo)
 
 
-def get_month_year_bounds(month: int, year: int, lenient=False) -> tuple[datetime, datetime]:
+def get_month_year_bounds(
+    month: int, year: int, lenient=False
+) -> tuple[datetime, datetime]:
     """Given a month and year, return the two dates that bound that month (ie.
     the first day of the month, and the first day of the next month). If lenient
     is true, then the lower and upper date bounds will use the most lenient
-    timezones possible. """
+    timezones possible."""
 
     lower_timezone = None
     upper_timezone = None
@@ -115,10 +117,14 @@ def get_month_year_bounds(month: int, year: int, lenient=False) -> tuple[datetim
     lower_bound = datetime(year, month, 1, tzinfo=lower_timezone)
     upper_bound = None
     if month < 12:
-        upper_bound = lower_bound.replace(month=lower_bound.month + 1, tzinfo=upper_timezone)
+        upper_bound = lower_bound.replace(
+            month=lower_bound.month + 1, tzinfo=upper_timezone
+        )
     else:
-        upper_bound = lower_bound.replace(year=lower_bound.year + 1, month=1, tzinfo=upper_timezone)
-    
+        upper_bound = lower_bound.replace(
+            year=lower_bound.year + 1, month=1, tzinfo=upper_timezone
+        )
+
     return lower_bound, upper_bound
 
 
@@ -144,7 +150,11 @@ def guess_voting_month_year(ballots: list[Ballot]) -> tuple[int, int, bool]:
             voting_month_year_counts[month_year] = 0
         voting_month_year_counts[month_year] += 1
 
-    sorted_voting_month_years = sorted(voting_month_year_counts, key=lambda my: voting_month_year_counts[my], reverse=True)
+    sorted_voting_month_years = sorted(
+        voting_month_year_counts,
+        key=lambda my: voting_month_year_counts[my],
+        reverse=True,
+    )
 
     most_popular_month_year = sorted_voting_month_years[0]
     is_unanimous = len(sorted_voting_month_years) == 1

--- a/functions/date.py
+++ b/functions/date.py
@@ -3,6 +3,7 @@
 import re
 from datetime import datetime
 from pytz import timezone
+from classes.voting import Ballot
 
 
 def parse_votes_csv_timestamp(timestamp: str) -> datetime:
@@ -94,18 +95,30 @@ def get_preceding_month_date(date: datetime) -> datetime:
     return datetime(preceding_year, preceding_month, 1, tzinfo=date.tzinfo)
 
 
-def get_month_bounds(date: datetime) -> tuple[datetime, datetime]:
-    """Given a date, return the two dates that bound that date's month (ie. the
-    first day of the month, and the first day of the next month).
-    """
-    lower_bound = date.replace(day=1)
+def get_month_year_bounds(month: int, year: int, lenient=False) -> tuple[datetime, datetime]:
+    """Given a month and year, return the two dates that bound that month (ie.
+    the first day of the month, and the first day of the next month). If lenient
+    is true, then the lower and upper date bounds will use the most lenient
+    timezones possible. """
+
+    lower_timezone = None
+    upper_timezone = None
+
+    # If leniency is requested, use the following timezones for the lower and
+    # upper date bounds:
+    # * Lower: Kiribati, UTC+14:00
+    # * Upper: International Date Line West (IDLW), UTC:-12:00
+    if lenient:
+        lower_timezone = timezone("Etc/GMT-14")
+        upper_timezone = timezone("Etc/GMT+12")
+
+    lower_bound = datetime(year, month, 1, tzinfo=lower_timezone)
     upper_bound = None
-
-    if lower_bound.month < 12:
-        upper_bound = lower_bound.replace(month=lower_bound.month + 1, day=1)
+    if month < 12:
+        upper_bound = lower_bound.replace(month=lower_bound.month + 1, tzinfo=upper_timezone)
     else:
-        upper_bound = lower_bound.replace(year=lower_bound.year + 1, month=1, day=1)
-
+        upper_bound = lower_bound.replace(year=lower_bound.year + 1, month=1, tzinfo=upper_timezone)
+    
     return lower_bound, upper_bound
 
 
@@ -114,3 +127,26 @@ def is_date_between(
 ) -> bool:
     """Return True if the given date is between the given bounds."""
     return date >= lower_bound and date < upper_bound
+
+
+def guess_voting_month_year(ballots: list[Ballot]) -> tuple[int, int, bool]:
+    """Given a list of ballots, attempt to determine what month and year is
+    being voted on. This uses a simple heuristic of counting the most popular
+    month-year in the ballot timestamps.
+
+    Returns a tuple of 3 values: month, year, and is_unanimous, which is set to
+    True if all ballots agreed on the same month and year."""
+    voting_month_year_counts = {}
+
+    for ballot in ballots:
+        month_year = (ballot.timestamp.month, ballot.timestamp.year)
+        if month_year not in voting_month_year_counts:
+            voting_month_year_counts[month_year] = 0
+        voting_month_year_counts[month_year] += 1
+
+    sorted_voting_month_years = sorted(voting_month_year_counts, key=lambda my: voting_month_year_counts[my], reverse=True)
+
+    most_popular_month_year = sorted_voting_month_years[0]
+    is_unanimous = len(sorted_voting_month_years) == 1
+
+    return (*most_popular_month_year, is_unanimous)

--- a/functions/video_rules.py
+++ b/functions/video_rules.py
@@ -4,6 +4,8 @@ _vote_ for a video, which happens in `functions/ballot_rules.py`. Some of the
 vote checks rely on videos having been checked and annotated first."""
 
 from datetime import datetime
+from pytz import timezone
+from functions.date import get_month_year_bounds
 from classes.voting import Video
 
 
@@ -26,18 +28,17 @@ def check_uploader_whitelist(videos: list[Video], whitelisted_uploaders: list[st
             video.annotations.add("NOT WHITELISTED")
 
 
-def check_upload_date(videos: list[Video], month_date: datetime):
+def check_upload_date(videos: list[Video], month: int, year: int):
     """Check the given list of videos to make sure they were released in the
     given month. Annotate any videos that were released too early or too late.
+
+    For maximum leniency, the lower and upper date bounds are in the earliest
+    and latest timezones respectively; this means, for example, that a video
+    uploaded on 1st April could still be eligible for the March voting as long
+    as it was still March _somewhere_ in the world when it was uploaded.
     """
 
-    lower_bound = month_date.replace(day=1)
-
-    upper_bound = None
-    if month_date.month < 12:
-        upper_bound = lower_bound.replace(month=lower_bound.month + 1, day=1)
-    else:
-        upper_bound = lower_bound.replace(year=lower_bound.year + 1, month=1, day=1)
+    lower_bound, upper_bound = get_month_year_bounds(month, year, True)
 
     for video in videos:
         upload_date = video.data["upload_date"]

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from functions.voting import (
     fetch_video_data_for_ballots,
     generate_annotated_csv_data,
 )
-from functions.date import get_preceding_month_date, is_date_between, get_month_bounds
+from functions.date import get_preceding_month_date, is_date_between, get_month_year_bounds, guess_voting_month_year
 from functions.video_rules import (
     check_uploader_blacklist,
     check_uploader_whitelist,
@@ -79,11 +79,7 @@ def run_checks():
         tk.messagebox.showinfo("Error", "Please select a CSV file first.")
         return
 
-    selected_checks = [
-        name
-        for name in check_vars
-        if check_vars[name].get() == True and name != "debug"
-    ]
+    selected_checks = [name for name in check_vars if check_vars[name].get() == True]
 
     if len(selected_checks) == 0:
         tk.messagebox.showinfo("Error", "Please select at least one check type.")
@@ -128,25 +124,53 @@ def run_checks():
 
     suc(f"Loaded {len(ballots)} ballots containing a total of {total_votes} votes.")
 
-    for ballot in ballots:
-        ballot.timestamp = ballot.timestamp.replace(tzinfo=CONFIG["timezone"])
+    # Date calculations. There are 3 dates we need to be aware of:
+    # Voting date:  The date of the month and year in which the votes were cast.
+    #               For example, April 2024. For convenience, we represent this
+    #               as a datetime, set to the 1st of the voting month.
+    # Upload date:  The date of the month and year in which the videos being
+    #               voted on were uploaded. The voting rules require this to be
+    #               the month prior to the voting month; ie. if votes were cast
+    #               in April 2024, then the votes must be for videos that were
+    #               uploaded in March 2024.
+    # Current date: The date when the user is running this Python application.
+    #               In normal usage, the user will run this in the same month as
+    #               the voting month. However, during development, it's common
+    #               to use old data for testing. The user will be warned if they
+    #               are using old data.
 
-    inf(f'Converting all ballot timestamps to the {CONFIG["timezone"]} timezone.')
-    voting_month_date = datetime.now(tz=CONFIG["timezone"])
+    voting_month, voting_year, is_voting_date_unanimous = guess_voting_month_year(ballots)
+    voting_month_date = datetime(voting_year, voting_month, 1)
+    voting_month_year_str = voting_month_date.strftime("%B %Y")
+
+    if not is_voting_date_unanimous:
+        voting_date_discrepancy_warning = f'Warning: the majority of the ballot timestamps are for {voting_month_year_str}; however, some are for a different month and date. Assuming a voting month of {voting_month_year_str}.'
+        err(voting_date_discrepancy_warning)
+        tk.messagebox.showinfo("Warning", voting_date_discrepancy_warning)
+
     upload_month_date = get_preceding_month_date(voting_month_date)
+    upload_month_year_str = upload_month_date.strftime("%B %Y")
+
+    current_month_date = datetime.now()
+    current_month_year_str = current_month_date.strftime("%B %Y")
 
     # Give a warning in the console if the CSV is for a different month than the
     # current one.
     anachronistic_ballots = [
         ballot
         for ballot in ballots
-        if not is_date_between(ballot.timestamp, *get_month_bounds(voting_month_date))
+        if not is_date_between(ballot.timestamp, *get_month_year_bounds(current_month_date.month, current_month_date.year))
     ]
+
     if len(anachronistic_ballots) > 0:
-        voting_month_year_str = voting_month_date.strftime("%B %Y")
         err(
-            f"Warning: the input CSV contains votes that do not fall within the current month ({voting_month_year_str})."
+            f"Warning: the input CSV contains votes that do not fall within the current month ({current_month_year_str})."
         )
+
+    inf(f'Date information:')
+    inf(f'* Upload month:  {upload_month_year_str}')
+    inf(f'* Voting month:  {voting_month_year_str}')
+    inf(f'* Current month: {current_month_year_str}')
 
     # Fetch data for all video URLs that were voted on. The data is indexed by
     # URL to allow lookups when checking the votes. Note that some videos may
@@ -187,7 +211,7 @@ def run_checks():
     check_uploader_whitelist(videos_with_data.values(), whitelist)
 
     inf(f"* Checking video upload dates...")
-    check_upload_date(videos_with_data.values(), upload_month_date)
+    check_upload_date(videos_with_data.values(), upload_month_date.month, upload_month_date.year)
 
     inf(f"* Checking video durations...")
     check_duration(videos_with_data.values())

--- a/main.py
+++ b/main.py
@@ -13,7 +13,12 @@ from functions.voting import (
     fetch_video_data_for_ballots,
     generate_annotated_csv_data,
 )
-from functions.date import get_preceding_month_date, is_date_between, get_month_year_bounds, guess_voting_month_year
+from functions.date import (
+    get_preceding_month_date,
+    is_date_between,
+    get_month_year_bounds,
+    guess_voting_month_year,
+)
 from functions.video_rules import (
     check_uploader_blacklist,
     check_uploader_whitelist,
@@ -139,12 +144,14 @@ def run_checks():
     #               to use old data for testing. The user will be warned if they
     #               are using old data.
 
-    voting_month, voting_year, is_voting_date_unanimous = guess_voting_month_year(ballots)
+    voting_month, voting_year, is_voting_date_unanimous = guess_voting_month_year(
+        ballots
+    )
     voting_month_date = datetime(voting_year, voting_month, 1)
     voting_month_year_str = voting_month_date.strftime("%B %Y")
 
     if not is_voting_date_unanimous:
-        voting_date_discrepancy_warning = f'Warning: the majority of the ballot timestamps are for {voting_month_year_str}; however, some are for a different month and date. Assuming a voting month of {voting_month_year_str}.'
+        voting_date_discrepancy_warning = f"Warning: the majority of the ballot timestamps are for {voting_month_year_str}; however, some are for a different month and date. Assuming a voting month of {voting_month_year_str}."
         err(voting_date_discrepancy_warning)
         tk.messagebox.showinfo("Warning", voting_date_discrepancy_warning)
 
@@ -159,7 +166,10 @@ def run_checks():
     anachronistic_ballots = [
         ballot
         for ballot in ballots
-        if not is_date_between(ballot.timestamp, *get_month_year_bounds(current_month_date.month, current_month_date.year))
+        if not is_date_between(
+            ballot.timestamp,
+            *get_month_year_bounds(current_month_date.month, current_month_date.year),
+        )
     ]
 
     if len(anachronistic_ballots) > 0:
@@ -167,10 +177,10 @@ def run_checks():
             f"Warning: the input CSV contains votes that do not fall within the current month ({current_month_year_str})."
         )
 
-    inf(f'Date information:')
-    inf(f'* Upload month:  {upload_month_year_str}')
-    inf(f'* Voting month:  {voting_month_year_str}')
-    inf(f'* Current month: {current_month_year_str}')
+    inf(f"Date information:")
+    inf(f"* Upload month:  {upload_month_year_str}")
+    inf(f"* Voting month:  {voting_month_year_str}")
+    inf(f"* Current month: {current_month_year_str}")
 
     # Fetch data for all video URLs that were voted on. The data is indexed by
     # URL to allow lookups when checking the votes. Note that some videos may
@@ -211,7 +221,9 @@ def run_checks():
     check_uploader_whitelist(videos_with_data.values(), whitelist)
 
     inf(f"* Checking video upload dates...")
-    check_upload_date(videos_with_data.values(), upload_month_date.month, upload_month_date.year)
+    check_upload_date(
+        videos_with_data.values(), upload_month_date.month, upload_month_date.year
+    )
 
     inf(f"* Checking video durations...")
     check_duration(videos_with_data.values())

--- a/tests/functions/date.py
+++ b/tests/functions/date.py
@@ -154,7 +154,6 @@ class TestFunctionsDate(TestCase):
 
         date = datetime(2025, 2, 1)
         self.assertFalse(is_date_between(date, lower_bound, upper_bound))
-        
 
     def test_guess_voting_month_year(self):
         ballots = [

--- a/tests/functions/date.py
+++ b/tests/functions/date.py
@@ -5,9 +5,11 @@ from functions.date import (
     parse_votes_csv_timestamp,
     format_votes_csv_timestamp,
     get_preceding_month_date,
-    get_month_bounds,
+    get_month_year_bounds,
     is_date_between,
+    guess_voting_month_year,
 )
+from classes.voting import Ballot
 
 
 class TestFunctionsDate(TestCase):
@@ -45,11 +47,10 @@ class TestFunctionsDate(TestCase):
         date = datetime(2024, 2, 14)
         self.assertEqual(datetime(2024, 1, 1), get_preceding_month_date(date))
 
-    def test_get_month_bounds(self):
+    def test_get_month_year_bounds(self):
         # Test January to November
         for month in range(1, 12):
-            date = datetime(2024, month, 14)
-            lower_bound, upper_bound = get_month_bounds(date)
+            lower_bound, upper_bound = get_month_year_bounds(month, 2024)
             self.assertEqual(lower_bound.year, upper_bound.year)
             self.assertEqual(1, upper_bound.day)
             self.assertEqual(month, lower_bound.month)
@@ -58,8 +59,7 @@ class TestFunctionsDate(TestCase):
             self.assertEqual(1, upper_bound.day)
 
         # Test that December's upper bound is the start of next year
-        date = datetime(2024, 12, 25)
-        lower_bound, upper_bound = get_month_bounds(date)
+        lower_bound, upper_bound = get_month_year_bounds(12, 2024)
         self.assertEqual(12, lower_bound.month)
         self.assertEqual(1, upper_bound.month)
         self.assertEqual(lower_bound.year + 1, upper_bound.year)
@@ -154,3 +154,62 @@ class TestFunctionsDate(TestCase):
 
         date = datetime(2025, 2, 1)
         self.assertFalse(is_date_between(date, lower_bound, upper_bound))
+        
+
+    def test_guess_voting_month_year(self):
+        ballots = [
+            Ballot(datetime(2024, 4, 1), []),
+            Ballot(datetime(2024, 4, 2), []),
+            Ballot(datetime(2024, 4, 10), []),
+            Ballot(datetime(2024, 4, 20), []),
+            Ballot(datetime(2024, 4, 29), []),
+            Ballot(datetime(2024, 4, 30), []),
+        ]
+
+        month, year, is_unanimous = guess_voting_month_year(ballots)
+
+        self.assertEqual(4, month)
+        self.assertEqual(2024, year)
+        self.assertTrue(is_unanimous)
+
+        ballots = [
+            Ballot(datetime(2024, 3, 31), []),
+            Ballot(datetime(2024, 4, 1), []),
+            Ballot(datetime(2024, 4, 2), []),
+        ]
+
+        month, year, is_unanimous = guess_voting_month_year(ballots)
+
+        self.assertEqual(4, month)
+        self.assertEqual(2024, year)
+        self.assertFalse(is_unanimous)
+
+        ballots = [
+            Ballot(datetime(2012, 4, 1), []),
+            Ballot(datetime(2024, 4, 1), []),
+            Ballot(datetime(2024, 4, 1), []),
+        ]
+
+        month, year, is_unanimous = guess_voting_month_year(ballots)
+
+        self.assertEqual(4, month)
+        self.assertEqual(2024, year)
+        self.assertFalse(is_unanimous)
+
+        ballots = [
+            Ballot(datetime(2020, 4, 1), []),
+            Ballot(datetime(2021, 4, 1), []),
+            Ballot(datetime(2022, 4, 1), []),
+            Ballot(datetime(2023, 4, 1), []),
+            Ballot(datetime(2024, 4, 1), []),
+            Ballot(datetime(2024, 4, 2), []),
+            Ballot(datetime(2025, 4, 3), []),
+            Ballot(datetime(2026, 4, 3), []),
+            Ballot(datetime(2027, 4, 3), []),
+        ]
+
+        month, year, is_unanimous = guess_voting_month_year(ballots)
+
+        self.assertEqual(4, month)
+        self.assertEqual(2024, year)
+        self.assertFalse(is_unanimous)

--- a/tests/functions/video_rules.py
+++ b/tests/functions/video_rules.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from datetime import datetime
+from pytz import timezone
 from classes.voting import Video
 from functions.video_rules import (
     check_uploader_blacklist,
@@ -53,36 +54,39 @@ class TestFunctionsVideoRules(TestCase):
         self.assertFalse(videos[5].annotations.has("NOT WHITELISTED"))
 
     def test_check_upload_date(self):
+        utc = timezone('Etc/UTC')
         videos = [
             # Too old
-            Video({"title": "Example Video 1", "upload_date": datetime(1912, 4, 15)}),
-            Video({"title": "Example Video 2", "upload_date": datetime(2000, 1, 1)}),
-            Video({"title": "Example Video 3", "upload_date": datetime(2000, 1, 1)}),
-            Video({"title": "Example Video 4", "upload_date": datetime(2023, 2, 14)}),
-            Video({"title": "Example Video 5", "upload_date": datetime(2023, 12, 31)}),
-            Video({"title": "Example Video 6", "upload_date": datetime(2024, 1, 1)}),
-            Video({"title": "Example Video 7", "upload_date": datetime(2024, 1, 31)}),
+            Video({"title": "Example Video 1", "upload_date": datetime(1912, 4, 15, tzinfo=utc)}),
+            Video({"title": "Example Video 2", "upload_date": datetime(2000, 1, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 3", "upload_date": datetime(2000, 1, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 4", "upload_date": datetime(2023, 2, 14, tzinfo=utc)}),
+            Video({"title": "Example Video 5", "upload_date": datetime(2023, 12, 31, tzinfo=utc)}),
+            Video({"title": "Example Video 6", "upload_date": datetime(2024, 1, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 7", "upload_date": datetime(2024, 1, 31, tzinfo=utc)}),
             # Within date
-            Video({"title": "Example Video 8", "upload_date": datetime(2024, 2, 1)}),
-            Video({"title": "Example Video 9", "upload_date": datetime(2024, 2, 1)}),
-            Video({"title": "Example Video 10", "upload_date": datetime(2024, 2, 14)}),
-            Video({"title": "Example Video 11", "upload_date": datetime(2024, 2, 28)}),
-            Video({"title": "Example Video 12", "upload_date": datetime(2024, 2, 29)}),
+            Video({"title": "Example Video 8", "upload_date": datetime(2024, 1, 31, 13, 0, 0, tzinfo=utc)}),
+            Video({"title": "Example Video 9", "upload_date": datetime(2024, 2, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 10", "upload_date": datetime(2024, 2, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 11", "upload_date": datetime(2024, 2, 14, tzinfo=utc)}),
+            Video({"title": "Example Video 12", "upload_date": datetime(2024, 2, 28, tzinfo=utc)}),
+            Video({"title": "Example Video 13", "upload_date": datetime(2024, 2, 29, tzinfo=utc)}),
+            Video({"title": "Example Video 14", "upload_date": datetime(2024, 3, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 15", "upload_date": datetime(2024, 3, 1, 10, 0, 0, tzinfo=utc)}),
             # Too new
-            Video({"title": "Example Video 13", "upload_date": datetime(2024, 3, 1)}),
-            Video({"title": "Example Video 14", "upload_date": datetime(2024, 3, 2)}),
-            Video({"title": "Example Video 15", "upload_date": datetime(2024, 4, 1)}),
-            Video({"title": "Example Video 16", "upload_date": datetime(2024, 12, 31)}),
-            Video({"title": "Example Video 17", "upload_date": datetime(2025, 2, 1)}),
-            Video({"title": "Example Video 18", "upload_date": datetime(2025, 2, 14)}),
-            Video({"title": "Example Video 19", "upload_date": datetime(2025, 2, 28)}),
-            Video({"title": "Example Video 20", "upload_date": datetime(2025, 3, 1)}),
-            Video({"title": "Example Video 21", "upload_date": datetime(3025, 1, 1)}),
-            Video({"title": "Example Video 22", "upload_date": datetime(9999, 12, 31)}),
+            Video({"title": "Example Video 16", "upload_date": datetime(2024, 3, 2, tzinfo=utc)}),
+            Video({"title": "Example Video 17", "upload_date": datetime(2024, 4, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 18", "upload_date": datetime(2024, 12, 31, tzinfo=utc)}),
+            Video({"title": "Example Video 19", "upload_date": datetime(2025, 2, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 20", "upload_date": datetime(2025, 2, 14, tzinfo=utc)}),
+            Video({"title": "Example Video 21", "upload_date": datetime(2025, 2, 28, tzinfo=utc)}),
+            Video({"title": "Example Video 22", "upload_date": datetime(2025, 3, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 23", "upload_date": datetime(3025, 1, 1, tzinfo=utc)}),
+            Video({"title": "Example Video 24", "upload_date": datetime(9999, 12, 31, tzinfo=utc)}),
         ]
 
-        month_date = datetime(2024, 2, 14)
-        check_upload_date(videos, month_date)
+        # Check videos to make sure they were uploaded in February 2024
+        check_upload_date(videos, 2, 2024)
 
         self.assertTrue(videos[0].annotations.has("VIDEO TOO OLD"))
         self.assertTrue(videos[1].annotations.has("VIDEO TOO OLD"))
@@ -91,14 +95,22 @@ class TestFunctionsVideoRules(TestCase):
         self.assertTrue(videos[4].annotations.has("VIDEO TOO OLD"))
         self.assertTrue(videos[5].annotations.has("VIDEO TOO OLD"))
         self.assertTrue(videos[6].annotations.has("VIDEO TOO OLD"))
+        # Note that videos[7], uploaded on 31st January 2024, is not considered
+        # too old, even though it was uploaded in the preceding month - that's
+        # because at the time it was uploaded (13:00 in UTC), it was already 1st
+        # February in Kiribati, the earliest timezone.
         self.assertTrue(videos[7].annotations.has_none())
         self.assertTrue(videos[8].annotations.has_none())
         self.assertTrue(videos[9].annotations.has_none())
         self.assertTrue(videos[10].annotations.has_none())
         self.assertTrue(videos[11].annotations.has_none())
-        self.assertTrue(videos[12].annotations.has("VIDEO TOO NEW"))
-        self.assertTrue(videos[13].annotations.has("VIDEO TOO NEW"))
-        self.assertTrue(videos[14].annotations.has("VIDEO TOO NEW"))
+        self.assertTrue(videos[12].annotations.has_none())
+        # Note that videos[13] and videos[14], uploaded on 1st March 2024, are
+        # not considered too new, even though they were uploaded in the
+        # following month - that's because while it's 1st March in the UTC
+        # timezone, there are places in the world where it's still 29th February.
+        self.assertTrue(videos[13].annotations.has_none())
+        self.assertTrue(videos[14].annotations.has_none())
         self.assertTrue(videos[15].annotations.has("VIDEO TOO NEW"))
         self.assertTrue(videos[16].annotations.has("VIDEO TOO NEW"))
         self.assertTrue(videos[17].annotations.has("VIDEO TOO NEW"))
@@ -106,6 +118,8 @@ class TestFunctionsVideoRules(TestCase):
         self.assertTrue(videos[19].annotations.has("VIDEO TOO NEW"))
         self.assertTrue(videos[20].annotations.has("VIDEO TOO NEW"))
         self.assertTrue(videos[21].annotations.has("VIDEO TOO NEW"))
+        self.assertTrue(videos[22].annotations.has("VIDEO TOO NEW"))
+        self.assertTrue(videos[23].annotations.has("VIDEO TOO NEW"))
 
     def test_check_duration(self):
         videos = [

--- a/tests/functions/video_rules.py
+++ b/tests/functions/video_rules.py
@@ -54,35 +54,155 @@ class TestFunctionsVideoRules(TestCase):
         self.assertFalse(videos[5].annotations.has("NOT WHITELISTED"))
 
     def test_check_upload_date(self):
-        utc = timezone('Etc/UTC')
+        utc = timezone("Etc/UTC")
         videos = [
             # Too old
-            Video({"title": "Example Video 1", "upload_date": datetime(1912, 4, 15, tzinfo=utc)}),
-            Video({"title": "Example Video 2", "upload_date": datetime(2000, 1, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 3", "upload_date": datetime(2000, 1, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 4", "upload_date": datetime(2023, 2, 14, tzinfo=utc)}),
-            Video({"title": "Example Video 5", "upload_date": datetime(2023, 12, 31, tzinfo=utc)}),
-            Video({"title": "Example Video 6", "upload_date": datetime(2024, 1, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 7", "upload_date": datetime(2024, 1, 31, tzinfo=utc)}),
+            Video(
+                {
+                    "title": "Example Video 1",
+                    "upload_date": datetime(1912, 4, 15, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 2",
+                    "upload_date": datetime(2000, 1, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 3",
+                    "upload_date": datetime(2000, 1, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 4",
+                    "upload_date": datetime(2023, 2, 14, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 5",
+                    "upload_date": datetime(2023, 12, 31, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 6",
+                    "upload_date": datetime(2024, 1, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 7",
+                    "upload_date": datetime(2024, 1, 31, tzinfo=utc),
+                }
+            ),
             # Within date
-            Video({"title": "Example Video 8", "upload_date": datetime(2024, 1, 31, 13, 0, 0, tzinfo=utc)}),
-            Video({"title": "Example Video 9", "upload_date": datetime(2024, 2, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 10", "upload_date": datetime(2024, 2, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 11", "upload_date": datetime(2024, 2, 14, tzinfo=utc)}),
-            Video({"title": "Example Video 12", "upload_date": datetime(2024, 2, 28, tzinfo=utc)}),
-            Video({"title": "Example Video 13", "upload_date": datetime(2024, 2, 29, tzinfo=utc)}),
-            Video({"title": "Example Video 14", "upload_date": datetime(2024, 3, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 15", "upload_date": datetime(2024, 3, 1, 10, 0, 0, tzinfo=utc)}),
+            Video(
+                {
+                    "title": "Example Video 8",
+                    "upload_date": datetime(2024, 1, 31, 13, 0, 0, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 9",
+                    "upload_date": datetime(2024, 2, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 10",
+                    "upload_date": datetime(2024, 2, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 11",
+                    "upload_date": datetime(2024, 2, 14, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 12",
+                    "upload_date": datetime(2024, 2, 28, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 13",
+                    "upload_date": datetime(2024, 2, 29, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 14",
+                    "upload_date": datetime(2024, 3, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 15",
+                    "upload_date": datetime(2024, 3, 1, 10, 0, 0, tzinfo=utc),
+                }
+            ),
             # Too new
-            Video({"title": "Example Video 16", "upload_date": datetime(2024, 3, 2, tzinfo=utc)}),
-            Video({"title": "Example Video 17", "upload_date": datetime(2024, 4, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 18", "upload_date": datetime(2024, 12, 31, tzinfo=utc)}),
-            Video({"title": "Example Video 19", "upload_date": datetime(2025, 2, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 20", "upload_date": datetime(2025, 2, 14, tzinfo=utc)}),
-            Video({"title": "Example Video 21", "upload_date": datetime(2025, 2, 28, tzinfo=utc)}),
-            Video({"title": "Example Video 22", "upload_date": datetime(2025, 3, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 23", "upload_date": datetime(3025, 1, 1, tzinfo=utc)}),
-            Video({"title": "Example Video 24", "upload_date": datetime(9999, 12, 31, tzinfo=utc)}),
+            Video(
+                {
+                    "title": "Example Video 16",
+                    "upload_date": datetime(2024, 3, 2, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 17",
+                    "upload_date": datetime(2024, 4, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 18",
+                    "upload_date": datetime(2024, 12, 31, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 19",
+                    "upload_date": datetime(2025, 2, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 20",
+                    "upload_date": datetime(2025, 2, 14, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 21",
+                    "upload_date": datetime(2025, 2, 28, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 22",
+                    "upload_date": datetime(2025, 3, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 23",
+                    "upload_date": datetime(3025, 1, 1, tzinfo=utc),
+                }
+            ),
+            Video(
+                {
+                    "title": "Example Video 24",
+                    "upload_date": datetime(9999, 12, 31, tzinfo=utc),
+                }
+            ),
         ]
 
         # Check videos to make sure they were uploaded in February 2024


### PR DESCRIPTION
* Improved leniency on the upload date check so that videos uploaded after the end of the month are still valid, as long as it's still the correct month somewhere in the world
* Added a function to automatically determine the voting month from the CSV, with a warning if the timestamps aren't unanimous
* Fixed a bug where the check for anachronistic ballots didn't calculate the month bounds correctly.