### PR TITLE
Replace YouTube URL regex with urlparse

### DIFF
--- a/functions/services.py
+++ b/functions/services.py
@@ -13,16 +13,18 @@ load_dotenv()
 API_KEY = os.getenv("apikey")  # may replace this
 ACCEPTED_DOMAINS_FILE = "data/accepted_domains.txt"
 
+
 def get_fetcher(prompt_for_missing_durs: bool = False) -> Fetcher:
     """Return the standard video fetcher used by the Top 10 Pony Videos
     applications (currently configured for YouTube and yt-dlp).
-    
+
     Parameters
     ----------
     prompt_when_missing_durs : bool, optional
         Determines the behavior when the response data is missing a duration.
         If set to True, the execution will be halted and the user will be prompted to manually enter a duration.
-        By default, it is set to False, so videos will be annotated as missing a duration instead of halting for manual input"""
+        By default, it is set to False, so videos will be annotated as missing a duration instead of halting for manual input
+    """
 
     inf("* Configuring video data fetcher...")
     fetcher = Fetcher()

--- a/functions/video_rules.py
+++ b/functions/video_rules.py
@@ -54,9 +54,9 @@ def check_duration(videos: list[Video]):
     """
     for video in videos:
         duration = video.data["duration"]
-        
-        if not duration:
-            video.annotations.add("MISSING DURATION")        
+
+        if duration is None:
+            video.annotations.add("MISSING DURATION")
         elif duration <= 30:
             video.annotations.add("VIDEO TOO SHORT")
         elif duration <= 45:

--- a/tests/classes/fetch_services.py
+++ b/tests/classes/fetch_services.py
@@ -31,6 +31,11 @@ class TestFetchServices(TestCase):
         self.assertTrue(service.can_fetch(url))
         self.assertEqual("Q8k4UTf8jiI", service.extract_video_id(url))
 
+        # Regular YouTube URL with `v=` as the second query parameter
+        url = "https://www.youtube.com/watch?app=desktop&v=KeXztnxcHbc"
+        self.assertTrue(service.can_fetch(url))
+        self.assertEqual("KeXztnxcHbc", service.extract_video_id(url))
+
         # Non-YouTube URL
         url = "https://pony.tube/w/2FCj5YvmdHy8AC2hkEbc9i"
         self.assertFalse(service.can_fetch(url))


### PR DESCRIPTION
Updated the YouTube video id extraction to use `urllib.parse.urlparse` instead of regex, which allows us to catch some more irregular cases such as the `v=` parameter not being first.