### PR TITLE
Update YT fetch service id extraction

### DIFF
--- a/classes/fetch_services.py
+++ b/classes/fetch_services.py
@@ -4,11 +4,11 @@ and `parse` methods."""
 
 import re, pytz, hashlib
 from datetime import datetime
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse
 from googleapiclient.discovery import build
 from yt_dlp import YoutubeDL
 from functions.date import convert_iso8601_duration_to_seconds
-from functions.url import is_youtube_url
+from functions.url import normalize_youtube_url
 from functions.messages import err
 from data.globals import ydl_opts
 from classes.exceptions import FetchRequestError, FetchParseError, VideoUnavailableError
@@ -28,28 +28,10 @@ class YouTubeFetchService:
         """Given a YouTube video URL, extract the video id from it, or None if
         no video id can be extracted."""
 
-        if not is_youtube_url(url):
+        try:
+            _, video_id = normalize_youtube_url(url)
+        except:
             return None
-
-        video_id = None
-
-        url_components = urlparse(url)
-        path = url_components.path
-        query_params = parse_qs(url_components.query)
-
-        # Regular YouTube URL: eg. https://www.youtube.com/watch?v=9RT4lfvVFhA
-        if path == "/watch":
-            video_id = query_params["v"][0]
-        else:
-            livestream_match = re.match("^/live/([a-zA-Z0-9_-]+)", path)
-            shortened_match = re.match("^/([a-zA-Z0-9_-]+)", path)
-
-            if livestream_match:
-                # Livestream URL: eg. https://www.youtube.com/live/Q8k4UTf8jiI
-                video_id = livestream_match.group(1)
-            elif shortened_match:
-                # Shortened YouTube URL: eg. https://youtu.be/9RT4lfvVFhA
-                video_id = shortened_match.group(1)
 
         return video_id
 

--- a/functions/similarity.py
+++ b/functions/similarity.py
@@ -105,7 +105,7 @@ def detect_cross_platform_uploads(videos: dict[str, Video]) -> dict[str, list[st
     # purpose of cross-platform comparisons, it's easier if we eliminate all
     # these variants and just have a single canonical URL for a given site.
     videos_with_data = {
-        normalize_youtube_url(url) if is_youtube_url(url) else url: video
+        normalize_youtube_url(url)[0] if is_youtube_url(url) else url: video
         for url, video in videos_with_data.items()
     }
 

--- a/functions/url.py
+++ b/functions/url.py
@@ -20,8 +20,8 @@ def is_youtube_url(url: str) -> bool:
 
 def normalize_youtube_url(url: str):
     """Given a YouTube URL which may contain various combinations and orderings
-    of query parameters, return a "normalized" URL which contains the minimal
-    set of parameters needed."""
+    of query parameters, return a "normalized" URL with the minimal
+    set of parameters needed, as well as the video id."""
 
     # Use urllib to break the URL into its relevant components.
     url_components = urlparse(url)
@@ -41,18 +41,20 @@ def normalize_youtube_url(url: str):
     # Mobile YouTube URL:       https://m.youtube.com/watch?v={VIDEO ID}
     # Livestream URL:           https://www.youtube.com/live/{VIDEO ID}
     # Shortened URL:            https://youtu.be/{VIDEO ID}
+    # Shorts URL                https://www.youtube.com/shorts/{VIDEO ID}
 
     video_id = None
     
-    if normal_match := re.match(r"^/watch/?\?(?:.*&)?v=([a-zA-Z0-9_-]+)", f"{path}?{url_components.query}"):
-        # Regular YouTube URL: eg. https://www.youtube.com/watch?v=9RT4lfvVFhA
-        video_id = normal_match.group(1)
-    elif shorts_match := re.match("/shorts/([a-zA-Z0-9_-]+)", path):
-        # Shorts URL: eg. https://www.youtube.com/shorts/5uFeg2BOPNo
-        video_id = shorts_match.group(1)
-    elif livestream_match := re.match("^/live/([a-zA-Z0-9_-]+)", path):
-        # Livestream URL: eg. https://www.youtube.com/live/Q8k4UTf8jiI
-        video_id = livestream_match.group(1)
+    if path.split("/")[1] in ["watch", "shorts", "live"]:
+        if normal_match := re.match(r"^/watch/?\?(?:.*&)?v=([a-zA-Z0-9_-]+)", f"{path}?{url_components.query}"):
+            # Regular YouTube URL: eg. https://www.youtube.com/watch?v=9RT4lfvVFhA
+            video_id = normal_match.group(1)
+        elif shorts_match := re.match("^/shorts/([a-zA-Z0-9_-]+)", path):
+            # Shorts URL: eg. https://www.youtube.com/shorts/5uFeg2BOPNo
+            video_id = shorts_match.group(1)
+        elif livestream_match := re.match("^/live/([a-zA-Z0-9_-]+)", path):
+            # Livestream URL: eg. https://www.youtube.com/live/Q8k4UTf8jiI
+            video_id = livestream_match.group(1)
     elif shortened_match := re.match("^/([a-zA-Z0-9_-]+)", path):
         # Shortened YouTube URL: eg. https://youtu.be/9RT4lfvVFhA
         video_id = shortened_match.group(1)
@@ -65,4 +67,4 @@ def normalize_youtube_url(url: str):
     # Using the video id, construct a normalized version of the YouTube URL.
     normalized_url = f"https://www.youtube.com/watch?v={video_id}"
 
-    return normalized_url
+    return normalized_url, video_id

--- a/functions/voting.py
+++ b/functions/voting.py
@@ -45,7 +45,7 @@ def normalize_voting_data(rows: list[list[str]]) -> list[list[str]]:
             if "://" not in cell:
                 cell = f"https://{cell}"
             if is_youtube_url(cell):
-                cell = normalize_youtube_url(cell)
+                cell, _ = normalize_youtube_url(cell)
 
             normalized_rows[row_idx][cell_idx] = cell
 

--- a/tests/functions/url.py
+++ b/tests/functions/url.py
@@ -18,24 +18,29 @@ class TestFunctionsUrl(TestCase):
 
         self.assertEqual(
             normalized_url,
-            normalize_youtube_url("https://www.youtube.com/watch?v=Q8k4UTf8jiI"),
+            normalize_youtube_url("https://www.youtube.com/watch?v=Q8k4UTf8jiI")[0],
         )
         self.assertEqual(
             normalized_url,
-            normalize_youtube_url("https://www.youtube.com/live/Q8k4UTf8jiI"),
+            normalize_youtube_url("https://www.youtube.com/live/Q8k4UTf8jiI")[0],
         )
         self.assertEqual(
-            normalized_url, normalize_youtube_url("https://youtu.be/Q8k4UTf8jiI")
+            normalized_url, normalize_youtube_url("https://youtu.be/Q8k4UTf8jiI")[0]
         )
         self.assertEqual(
             normalized_url,
             normalize_youtube_url(
                 "https://www.youtube.com/watch/?app=desktop&v=Q8k4UTf8jiI"
-            ),
+            )[0],
         )
         self.assertEqual(
             normalized_url,
-            normalize_youtube_url("https://www.youtube.com/shorts/Q8k4UTf8jiI/")
+            normalize_youtube_url("https://www.youtube.com/shorts/Q8k4UTf8jiI/")[0]
+        )
+
+        self.assertEqual(
+            "https://www.youtube.com/watch?v=watch000000",
+            normalize_youtube_url("https://youtu.be/watch000000?v=Q8k4UTf8jiI")[0]
         )
 
         # Malformed links should raise errors


### PR DESCRIPTION
This is mostly a non-issue since youtube urls are normalized beforehand, but I figured that in case the fetcher would ever get non normalized urls then we wouldn't have to write the same code from url.py twice
Also I noticed the shortened url case acted as an accidental fallback when it shouldn't, so that is also patched